### PR TITLE
Add ServerIPSender plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ServerIPSender Plugin
+
+This is a simple Paper plugin that stores the server's IP address and port into
+a file and sends the information to a plugin named `VelocityAPI` via plugin
+messaging. The data is written to `plugins/ServerIPSender/server-ip.txt` when
+the plugin is enabled.
+
+## Building
+
+Run `gradle build` to compile the plugin. The compiled JAR can be found in
+`build/libs`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly 'io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT'
+    compileOnly 'com.google.guava:guava:33.2.0-jre'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ServerIPSender'

--- a/src/main/java/com/example/serveripsender/ServerIPSender.java
+++ b/src/main/java/com/example/serveripsender/ServerIPSender.java
@@ -1,0 +1,59 @@
+package com.example.serveripsender;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.logging.Level;
+
+public class ServerIPSender extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        Server server = getServer();
+        String ip = server.getIp();
+        int port = server.getPort();
+        String ipPort = ip + ":" + port;
+
+        saveToFile(ipPort);
+        sendToVelocity(ipPort);
+    }
+
+    private void saveToFile(String ipPort) {
+        File dataDir = getDataFolder();
+        File file = new File(dataDir, "server-ip.txt");
+        try {
+            if (!dataDir.exists()) {
+                if (!dataDir.mkdirs()) {
+                    getLogger().warning("Could not create plugin data folder");
+                    return;
+                }
+            }
+            Files.writeString(file.toPath(), ipPort, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            getLogger().log(Level.SEVERE, "Could not write server IP", e);
+        }
+    }
+
+    private void sendToVelocity(String ipPort) {
+        Plugin velocity = getServer().getPluginManager().getPlugin("VelocityAPI");
+        if (velocity == null || !velocity.isEnabled()) {
+            getLogger().warning("VelocityAPI plugin not found or not enabled");
+            return;
+        }
+
+        String channel = "velocity:api";
+        getServer().getMessenger().registerOutgoingPluginChannel(this, channel);
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF("ServerAddress");
+        out.writeUTF(ipPort);
+        getServer().sendPluginMessage(this, channel, out.toByteArray());
+    }
+}
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,5 @@
+name: ServerIPSender
+main: com.example.serveripsender.ServerIPSender
+version: 1.0.0
+author: Codex
+api-version: "1.20"


### PR DESCRIPTION
## Summary
- set up Gradle project for a Paper plugin
- implement `ServerIPSender` that saves the server IP and port to a file and sends it to the `VelocityAPI` plugin
- document build instructions

## Testing
- `gradle build` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686aa998220c832e89bb26b6ca6e26ca