### PR TITLE
Add Pterodactyl API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,26 @@
 This is a simple Paper plugin that stores the server's IP address and port into
 a file and sends the information to a plugin named `VelocityAPI` via plugin
 messaging. The data is written to `plugins/ServerIPSender/server-ip.txt` when
-the plugin is enabled.
+the plugin is enabled. If configured with Pterodactyl API credentials, the
+plugin will query the panel for the server's default allocation and use that
+address instead of the local server configuration.
 
 ## Building
 
 Run `mvn package` to compile the plugin. The built JAR will be created in
 the `target` directory.
+
+## Configuration
+
+When the plugin first runs it creates a `config.yml` file. To obtain the server
+address from a Pterodactyl panel, fill in values for `pterodactyl-url`,
+`auth-token` and `server-id`:
+
+```
+pterodactyl-url: "https://your-panel.example.com"
+auth-token: "<API token>"
+server-id: <server id>
+```
+
+With these options set the plugin will query the panel for the default
+allocation and use that address when saving and sending the server IP.

--- a/pom.xml
+++ b/pom.xml
@@ -28,5 +28,10 @@
             <version>33.2.0-jre</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/example/serveripsender/ServerIPSender.java
+++ b/src/main/java/com/example/serveripsender/ServerIPSender.java
@@ -2,27 +2,84 @@ package com.example.serveripsender;
 
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
-import org.bukkit.Bukkit;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.logging.Level;
 
 public class ServerIPSender extends JavaPlugin {
+    private final Gson gson = new Gson();
     @Override
     public void onEnable() {
-        Server server = getServer();
-        String ip = server.getIp();
-        int port = server.getPort();
-        String ipPort = ip + ":" + port;
+        saveDefaultConfig();
+
+        String ipPort = fetchFromPterodactyl();
+        if (ipPort == null || ipPort.isBlank()) {
+            Server server = getServer();
+            String ip = server.getIp();
+            int port = server.getPort();
+            ipPort = ip + ":" + port;
+        }
 
         saveToFile(ipPort);
         sendToVelocity(ipPort);
+    }
+
+    private String fetchFromPterodactyl() {
+        String baseUrl = getConfig().getString("pterodactyl-url");
+        String token = getConfig().getString("auth-token");
+        String serverId = String.valueOf(getConfig().get("server-id"));
+
+        if (baseUrl == null || baseUrl.isBlank() ||
+                token == null || token.isBlank() ||
+                serverId == null || serverId.isBlank()) {
+            return null;
+        }
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/api/client/servers/" + serverId + "/network/allocations"))
+                    .header("Authorization", "Bearer " + token)
+                    .header("Accept", "application/json")
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                getLogger().warning("Failed to fetch allocation info from Pterodactyl: HTTP " + response.statusCode());
+                return null;
+            }
+
+            JsonObject obj = gson.fromJson(response.body(), JsonObject.class);
+            JsonArray data = obj.getAsJsonArray("data");
+            if (data == null) return null;
+            for (JsonElement el : data) {
+                JsonObject attr = el.getAsJsonObject().getAsJsonObject("attributes");
+                if (attr != null && attr.get("is_default").getAsBoolean()) {
+                    String ip = attr.has("alias") && !attr.get("alias").isJsonNull()
+                            ? attr.get("alias").getAsString() : attr.get("ip").getAsString();
+                    int port = attr.get("port").getAsInt();
+                    return ip + ":" + port;
+                }
+            }
+        } catch (Exception ex) {
+            getLogger().log(Level.WARNING, "Error contacting Pterodactyl API", ex);
+        }
+
+        return null;
     }
 
     private void saveToFile(String ipPort) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,7 @@
+# Configuration for ServerIPSender
+# Pterodactyl panel base URL, e.g. "https://cp.titannode.de"
+pterodactyl-url: ""
+# API key for the Pterodactyl account
+auth-token: ""
+# ID of the server to query allocations for
+server-id: 0


### PR DESCRIPTION
## Summary
- add GSON dependency for JSON parsing
- integrate optional Pterodactyl API call in `ServerIPSender`
- add `config.yml` template and document configuration

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aaca53968832e89a517c1b352d1ea